### PR TITLE
Fixed bug in UnitTestPeelStick

### DIFF
--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -129,7 +129,7 @@ proc testMessageLayer(substr, n, minLen, maxLen) throws {
   d.stop("make_strings");
   var reqMsg = "peel str %s %s str 1 True True True %jt".format(strings.offsetName, strings.valueName, [substr]);
   writeReq(reqMsg);
-  var repMsg = segmentedEfuncMsg(cmd="segmentedEfunc", payload=reqMsg.encode(), st);
+  var repMsg = segmentedPeelMsg(cmd="segmentedPeel", payload=reqMsg.encode(), st);
   writeRep(repMsg);
   var (loAttribs,lvAttribs,roAttribs,rvAttribs) = repMsg.splitMsgToTuple('+', 4);
   var loname = parseName(loAttribs);


### PR DESCRIPTION
At some point, arkouda/master updated the name of a function call in `test/UnitTestPeelStick.chpl`, and this fork somehow missed that change. This PR fixes the issue, and the corresponding unit test. It looks like the logging in arkouda/master has changed significantly, however, which may cause discrepancies between the unit test output and the known-good output in `test/UnitTestPeelStick.good`.